### PR TITLE
remove cjson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ git+https://github.com/xivo-pbx/xivo-lib-rest-client.git
 pika
 sqlalchemy
 psycopg2
-python-cjson
 python-ldap
 pyhamcrest
 requests

--- a/xivo_cti/cti/cti_message_codec.py
+++ b/xivo_cti/cti/cti_message_codec.py
@@ -43,7 +43,7 @@ class CTIMessageDecoder(object):
         return [self._decode_line(line) for line in lines[:-1]]
 
     def _decode_line(self, line):
-        return json.loads(line.decode('utf-8').replace('\\/', '/'))
+        return json.loads(line)
 
 
 class CTIMessageEncoder(object):

--- a/xivo_cti/cti/cti_message_codec.py
+++ b/xivo_cti/cti/cti_message_codec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2014 Avencall
+# Copyright (C) 2014-2015 Avencall
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-import cjson
+import json
 import time
 
 
@@ -48,11 +48,11 @@ class CTIMessageDecoder(object):
         # non-ASCII characters have not been decoded.
         # Without the .decode('utf-8'), some Unicode character (try asian, not european)
         # will not be interpreted correctly.
-        return cjson.decode(line.decode('utf-8').replace('\\/', '/'))
+        return json.loads(line.decode('utf-8').replace('\\/', '/'))
 
 
 class CTIMessageEncoder(object):
 
     def encode(self, msg):
         msg['timenow'] = time.time()
-        return cjson.encode(msg) + '\n'
+        return json.dumps(msg) + '\n'

--- a/xivo_cti/cti/cti_message_codec.py
+++ b/xivo_cti/cti/cti_message_codec.py
@@ -43,11 +43,6 @@ class CTIMessageDecoder(object):
         return [self._decode_line(line) for line in lines[:-1]]
 
     def _decode_line(self, line):
-        # This is the comment from the original serialJson class:
-        # Output of the cjson.decode is a Unicode object, even though the
-        # non-ASCII characters have not been decoded.
-        # Without the .decode('utf-8'), some Unicode character (try asian, not european)
-        # will not be interpreted correctly.
         return json.loads(line.decode('utf-8').replace('\\/', '/'))
 
 


### PR DESCRIPTION
the stdlib implementation in python > 2.6 is as good as the cjson implementation

http://stackoverflow.com/questions/706101/python-json-decoding-performance

python-cjson also conflicts with python-kombu on debian wheezy